### PR TITLE
Use ROEngines' models when installed

### DIFF
--- a/GameData/SPEngine/Parts/A4_proc.cfg
+++ b/GameData/SPEngine/Parts/A4_proc.cfg
@@ -12,7 +12,21 @@
 	!engineType = // prevent ROE from deleting us
 }
 
-+PART[Bumper_Engine_Unclad]:AFTER[ZREALPLUME]
++PART[Bumper_Engine_Unclad]:NEEDS[!ROEngines]:AFTER[ZREALPLUME]
+{
+	@name = SPEngineA4Unclad
+	@title = A-class Procedural Engine (Unclad)
+	@description = Alcohol/LOx atmospheric engine, like Aggregat or RD-100 series.  Without enclosing boattail.
+	MODULE
+	{
+		name = ModuleSPEngine
+		familyLetter = A
+	}
+	@identicalParts = Bumper_Engine,Bumper_Engine_Unclad
+	!engineType = // prevent ROE from deleting us
+}
+
++PART[ROE-A4]:NEEDS[ROEngines]:AFTER[ZREALPLUME]
 {
 	@name = SPEngineA4Unclad
 	@title = A-class Procedural Engine (Unclad)

--- a/GameData/SPEngine/Parts/A4_proc.cfg
+++ b/GameData/SPEngine/Parts/A4_proc.cfg
@@ -8,7 +8,7 @@
 		name = ModuleSPEngine
 		familyLetter = A
 	}
-	@identicalParts = Bumper_Engine,Bumper_Engine_Unclad
+	@identicalParts = SPEngineA4,SPEngineA4Unclad
 	!engineType = // prevent ROE from deleting us
 }
 
@@ -22,7 +22,7 @@
 		name = ModuleSPEngine
 		familyLetter = A
 	}
-	@identicalParts = Bumper_Engine,Bumper_Engine_Unclad
+	@identicalParts = SPEngineA4,SPEngineA4Unclad
 	!engineType = // prevent ROE from deleting us
 }
 
@@ -30,12 +30,12 @@
 {
 	@name = SPEngineA4Unclad
 	@title = A-class Procedural Engine (Unclad)
-	@description = Alcohol/LOx atmospheric engine, like Aggregat or RD-100 series.  Without enclosing boattail.
+	@description = Alcohol/LOx atmospheric engine, like Aggregat or RD-100 series.  Without enclosing boattail. <b><color=green>From ROEngines mod</color></b>
 	MODULE
 	{
 		name = ModuleSPEngine
 		familyLetter = A
 	}
-	@identicalParts = Bumper_Engine,Bumper_Engine_Unclad
+	@identicalParts = SPEngineA4,SPEngineA4Unclad
 	!engineType = // prevent ROE from deleting us
 }

--- a/GameData/SPEngine/Parts/AJ10_proc.cfg
+++ b/GameData/SPEngine/Parts/AJ10_proc.cfg
@@ -1,4 +1,18 @@
-+PART[SXTAJ10]:AFTER[ZREALPLUME]
++PART[SXTAJ10]:NEEDS[!ROEngines]:AFTER[ZREALPLUME]
+{
+	@name = SPEngineAJ10
+	@title = D-class Procedural Engine
+	@description = Pressure-fed hypergolic vacuum engine, like AJ10 family (Able, Delta, Apollo SPS...).  <b><color=green>From SXT mod</color></b>
+	MODULE
+	{
+		name = ModuleSPEngine
+		familyLetter = D
+	}
+	!identicalParts = // we're not identical to the part we copied!
+	!engineType = // prevent ROE from deleting us
+}
+
++PART[ROE-AJ10Mid]:NEEDS[ROEngines]:AFTER[ZREALPLUME]
 {
 	@name = SPEngineAJ10
 	@title = D-class Procedural Engine

--- a/GameData/SPEngine/Parts/AJ10_proc.cfg
+++ b/GameData/SPEngine/Parts/AJ10_proc.cfg
@@ -16,7 +16,7 @@
 {
 	@name = SPEngineAJ10
 	@title = D-class Procedural Engine
-	@description = Pressure-fed hypergolic vacuum engine, like AJ10 family (Able, Delta, Apollo SPS...).  <b><color=green>From SXT mod</color></b>
+	@description = Pressure-fed hypergolic vacuum engine, like AJ10 family (Able, Delta, Apollo SPS...).  <b><color=green>From ROEngines mod</color></b>
 	MODULE
 	{
 		name = ModuleSPEngine

--- a/GameData/SPEngine/Parts/Aerobee_proc.cfg
+++ b/GameData/SPEngine/Parts/Aerobee_proc.cfg
@@ -16,7 +16,7 @@
 {
 	@name = SPEngineWAC
 	@title = B-class Procedural Engine
-	@description = Small hypergolic sustainer engine, like Aerobee or very early AJ-10s.
+	@description = Small hypergolic sustainer engine, like Aerobee or very early AJ-10s. <b><color=green>From ROEngines mod</color></b>
 	MODULE
 	{
 		name = ModuleSPEngine

--- a/GameData/SPEngine/Parts/Aerobee_proc.cfg
+++ b/GameData/SPEngine/Parts/Aerobee_proc.cfg
@@ -1,4 +1,18 @@
-+PART[ROAerobeeSustainer]:AFTER[ZREALPLUME]
++PART[ROAerobeeSustainer]:NEEDS[!ROEngines]:AFTER[ZREALPLUME]
+{
+	@name = SPEngineWAC
+	@title = B-class Procedural Engine
+	@description = Small hypergolic sustainer engine, like Aerobee or very early AJ-10s.
+	MODULE
+	{
+		name = ModuleSPEngine
+		familyLetter = B
+	}
+	!identicalParts = // we're not identical to the part we copied!
+	!engineType = // prevent ROE from deleting us
+}
+
++PART[ROE-Aerobee]:NEEDS[ROEngines]:AFTER[ZREALPLUME]
 {
 	@name = SPEngineWAC
 	@title = B-class Procedural Engine

--- a/GameData/SPEngine/Parts/Agena_proc.cfg
+++ b/GameData/SPEngine/Parts/Agena_proc.cfg
@@ -16,7 +16,7 @@
 {
 	@name = SPEngineAgena
 	@title = G-class Procedural Engine
-	@description = Pump-fed hypergolic vacuum engine, like Agena (Bell XLR81).  <b><color=green>From Ven Stock Revamp mod</color></b>
+	@description = Pump-fed hypergolic vacuum engine, like Agena (Bell XLR81).  <b><color=green>From ROEngines mod</color></b>
 	MODULE
 	{
 		name = ModuleSPEngine

--- a/GameData/SPEngine/Parts/Agena_proc.cfg
+++ b/GameData/SPEngine/Parts/Agena_proc.cfg
@@ -1,4 +1,18 @@
-+PART[RO-AgenaEngine]:AFTER[ZREALPLUME]
++PART[RO-AgenaEngine]:NEEDS[!ROEngines]:AFTER[ZREALPLUME]
+{
+	@name = SPEngineAgena
+	@title = G-class Procedural Engine
+	@description = Pump-fed hypergolic vacuum engine, like Agena (Bell XLR81).  <b><color=green>From Ven Stock Revamp mod</color></b>
+	MODULE
+	{
+		name = ModuleSPEngine
+		familyLetter = G
+	}
+	!identicalParts = // we're not identical to the part we copied!
+	!engineType = // prevent ROE from deleting us
+}
+
++PART[ROE-Agena8048]:NEEDS[ROEngines]:AFTER[ZREALPLUME]
 {
 	@name = SPEngineAgena
 	@title = G-class Procedural Engine

--- a/GameData/SPEngine/Parts/F1_proc.cfg
+++ b/GameData/SPEngine/Parts/F1_proc.cfg
@@ -16,7 +16,7 @@
 {
 	@name = SPEngineF1
 	@title = F-class Procedural Engine
-	@description = Huge kerolox atmospheric engine, like F-1.
+	@description = Huge kerolox atmospheric engine, like F-1. <b><color=green>From ROEngines mod</color></b>
 	MODULE
 	{
 		name = ModuleSPEngine

--- a/GameData/SPEngine/Parts/F1_proc.cfg
+++ b/GameData/SPEngine/Parts/F1_proc.cfg
@@ -1,4 +1,18 @@
-+PART[Size3AdvancedEngine]:AFTER[ZREALPLUME]
++PART[Size3AdvancedEngine]:NEEDS[!ROEngines]:AFTER[ZREALPLUME]
+{
+	@name = SPEngineF1
+	@title = F-class Procedural Engine
+	@description = Huge kerolox atmospheric engine, like F-1.
+	MODULE
+	{
+		name = ModuleSPEngine
+		familyLetter = F // pay respects to Apollo
+	}
+	!identicalParts = // we're not identical to the part we copied!
+	!engineType = // prevent ROE from deleting us
+}
+
++PART[ROE-F1]:NEEDS[ROEngines]:AFTER[ZREALPLUME]
 {
 	@name = SPEngineF1
 	@title = F-class Procedural Engine

--- a/GameData/SPEngine/Parts/J2_proc.cfg
+++ b/GameData/SPEngine/Parts/J2_proc.cfg
@@ -1,4 +1,18 @@
-+PART[SXTLT80]:AFTER[ZREALPLUME]
++PART[SXTLT80]:NEEDS[!ROEngines]:AFTER[ZREALPLUME]
+{
+	@name = SPEngineJ2
+	@title = J-class Procedural Engine
+	@description = Large hydrolox vacuum engine, like J-2.
+	MODULE
+	{
+		name = ModuleSPEngine
+		familyLetter = J
+	}
+	@identicalParts = SPEngineJ2,SPEngineJ2T
+	!engineType = // prevent ROE from deleting us
+}
+
++PART[ROE-J2]:NEEDS[ROEngines]:AFTER[ZREALPLUME]
 {
 	@name = SPEngineJ2
 	@title = J-class Procedural Engine

--- a/GameData/SPEngine/Parts/J2_proc.cfg
+++ b/GameData/SPEngine/Parts/J2_proc.cfg
@@ -16,7 +16,7 @@
 {
 	@name = SPEngineJ2
 	@title = J-class Procedural Engine
-	@description = Large hydrolox vacuum engine, like J-2.
+	@description = Large hydrolox vacuum engine, like J-2. <b><color=green>From ROEngines mod</color></b>
 	MODULE
 	{
 		name = ModuleSPEngine

--- a/GameData/SPEngine/Parts/Kerovac.cfg
+++ b/GameData/SPEngine/Parts/Kerovac.cfg
@@ -1,4 +1,27 @@
-+PART[liquidEngine1-2]:BEFORE[ZREALPLUME]
++PART[liquidEngine1-2]:NEEDS[!ROEngines]:BEFORE[ZREALPLUME]
+{
+	@name = SPEngineLR91Kero
+	@title = V-class Procedural Engine
+	@description = Kerolox vacuum engine, like LR91 family (Titan I) and later SpaceX Merlin Vac.
+	@TechRequired = orbitalRocketry1959
+	MODULE
+	{
+		name = ModuleSPEngine
+		familyLetter = V
+	}
+	@identicalParts = SPEngineLR91Kero,SPEngineMVac // we're not identical to the part we copied!
+	!engineType = // prevent ROE from deleting us
+	@MODULE[ModuleEngines*]
+	{
+		%powerEffectName = Kerolox-Upper
+	}
+	@PLUME
+	{
+		@name = Kerolox-Upper
+	}
+}
+
++PART[ROE-LR91]:NEEDS[ROEngines]:BEFORE[ZREALPLUME]
 {
 	@name = SPEngineLR91Kero
 	@title = V-class Procedural Engine

--- a/GameData/SPEngine/Parts/Kerovac.cfg
+++ b/GameData/SPEngine/Parts/Kerovac.cfg
@@ -25,7 +25,7 @@
 {
 	@name = SPEngineLR91Kero
 	@title = V-class Procedural Engine
-	@description = Kerolox vacuum engine, like LR91 family (Titan I) and later SpaceX Merlin Vac.
+	@description = Kerolox vacuum engine, like LR91 family (Titan I) and later SpaceX Merlin Vac. <b><color=green>From ROEngines mod</color></b>
 	@TechRequired = orbitalRocketry1959
 	MODULE
 	{

--- a/GameData/SPEngine/Parts/LR105_proc.cfg
+++ b/GameData/SPEngine/Parts/LR105_proc.cfg
@@ -1,4 +1,18 @@
-+PART[RO-LR105]:AFTER[ZREALPLUME]
++PART[RO-LR105]:NEEDS[!ROEngines]:AFTER[ZREALPLUME]
+{
+	@name = SPEngineLR105
+	@title = L-class Procedural Engine
+	@description = Kerolox sustainer engine, like LR105 family.  Typically used in parallel-staging architectures, ground-lit alongside boosters.  As a sustainer engine, the L-class has relatively poor sea level specific impulse compared to most boosters, but somewhat better vacuum specific impulse--though the difference in both is nowhere near as pronounced as when comparing a booster to an upper stage engine.
+	MODULE
+	{
+		name = ModuleSPEngine
+		familyLetter = L
+	}
+	!identicalParts = // we're not identical to the part we copied!
+	!engineType = // prevent ROE from deleting us
+}
+
++PART[ROE-LR105]:NEEDS[ROEngines]:AFTER[ZREALPLUME]
 {
 	@name = SPEngineLR105
 	@title = L-class Procedural Engine

--- a/GameData/SPEngine/Parts/LR105_proc.cfg
+++ b/GameData/SPEngine/Parts/LR105_proc.cfg
@@ -16,7 +16,7 @@
 {
 	@name = SPEngineLR105
 	@title = L-class Procedural Engine
-	@description = Kerolox sustainer engine, like LR105 family.  Typically used in parallel-staging architectures, ground-lit alongside boosters.  As a sustainer engine, the L-class has relatively poor sea level specific impulse compared to most boosters, but somewhat better vacuum specific impulse--though the difference in both is nowhere near as pronounced as when comparing a booster to an upper stage engine.
+	@description = Kerolox sustainer engine, like LR105 family.  Typically used in parallel-staging architectures, ground-lit alongside boosters.  As a sustainer engine, the L-class has relatively poor sea level specific impulse compared to most boosters, but somewhat better vacuum specific impulse--though the difference in both is nowhere near as pronounced as when comparing a booster to an upper stage engine. <b><color=green>From ROEngines mod</color></b>
 	MODULE
 	{
 		name = ModuleSPEngine

--- a/GameData/SPEngine/Parts/LR79_proc.cfg
+++ b/GameData/SPEngine/Parts/LR79_proc.cfg
@@ -1,4 +1,4 @@
-+PART[liquidEngine1-2]:AFTER[ZREALPLUME]
++PART[liquidEngine1-2]:NEEDS[!ROEngines]:AFTER[ZREALPLUME]
 {
 	@name = SPEngineLR79
 	@title = K-class Procedural Engine
@@ -16,7 +16,39 @@
 	}
 }
 
-+PART[FASAApolloLFEH1]:AFTER[ZREALPLUME]
++PART[ROE-LR79]:NEEDS[ROEngines]:AFTER[ZREALPLUME]
+{
+	@name = SPEngineLR79
+	@title = K-class Procedural Engine
+	@description = Kerolox atmospheric engine, like LR79 family (and later SpaceX Merlin).
+	MODULE
+	{
+		name = ModuleSPEngine
+		familyLetter = K
+	}
+	@identicalParts = SPEngineLR79,SPEngineH1 // we're not identical to the part we copied!
+	!engineType = // prevent ROE from deleting us
+	@MODULE[ModuleEngines*]
+	{
+		%powerEffectName = Kerolox-Lower
+	}
+}
+
++PART[FASAApolloLFEH1]:NEEDS[!ROEngines]:AFTER[ZREALPLUME]
+{
+	@name = SPEngineH1
+	@title = K-class Procedural Engine (Alternate model)
+	@description = Kerolox atmospheric engine, like LR79 family (and later SpaceX Merlin).  This uses the same SPEngine configs as the plain K-class, it's just a different model.
+	MODULE
+	{
+		name = ModuleSPEngine
+		familyLetter = K
+	}
+	@identicalParts = SPEngineLR79,SPEngineH1 // we're not identical to the part we copied!
+	!engineType = // prevent ROE from deleting us
+}
+
++PART[ROE-H1C]:NEEDS[ROEngines]:AFTER[ZREALPLUME]
 {
 	@name = SPEngineH1
 	@title = K-class Procedural Engine (Alternate model)

--- a/GameData/SPEngine/Parts/LR79_proc.cfg
+++ b/GameData/SPEngine/Parts/LR79_proc.cfg
@@ -20,7 +20,7 @@
 {
 	@name = SPEngineLR79
 	@title = K-class Procedural Engine
-	@description = Kerolox atmospheric engine, like LR79 family (and later SpaceX Merlin).
+	@description = Kerolox atmospheric engine, like LR79 family (and later SpaceX Merlin). <b><color=green>From ROEngines mod</color></b>
 	MODULE
 	{
 		name = ModuleSPEngine
@@ -52,7 +52,7 @@
 {
 	@name = SPEngineH1
 	@title = K-class Procedural Engine (Alternate model)
-	@description = Kerolox atmospheric engine, like LR79 family (and later SpaceX Merlin).  This uses the same SPEngine configs as the plain K-class, it's just a different model.
+	@description = Kerolox atmospheric engine, like LR79 family (and later SpaceX Merlin).  This uses the same SPEngine configs as the plain K-class, it's just a different model. <b><color=green>From ROEngines mod</color></b>
 	MODULE
 	{
 		name = ModuleSPEngine

--- a/GameData/SPEngine/Parts/LR87_proc.cfg
+++ b/GameData/SPEngine/Parts/LR87_proc.cfg
@@ -1,4 +1,32 @@
-+PART[liquidEngine1-2]:BEFORE[ZREALPLUME]
++PART[liquidEngine1-2]:NEEDS[!ROEngines]:BEFORE[ZREALPLUME]
+{
+	@name = SPEngineLR87
+	@title = T-class Procedural Engine
+	@description = Hypergolic atmospheric engine, like LR87 family (Titan II and later).
+	@TechRequired = orbitalRocketry1962
+	@MODEL
+	{
+		// Original part had 0.69 each way.  We want it narrower — a cluster of two should fit on a Titan.
+		%scale = 0.5, 0.7, 0.5
+	}
+	MODULE
+	{
+		name = ModuleSPEngine
+		familyLetter = T
+	}
+	!identicalParts = // we're not identical to the part we copied!
+	!engineType = // prevent ROE from deleting us
+	@MODULE[ModuleEngines*]
+	{
+		%powerEffectName = Hypergolic-Lower
+	}
+	@PLUME
+	{
+		@name = Hypergolic-Lower
+	}
+}
+
++PART[ROE-LR87]:NEEDS[ROEngines]:BEFORE[ZREALPLUME]
 {
 	@name = SPEngineLR87
 	@title = T-class Procedural Engine

--- a/GameData/SPEngine/Parts/LR87_proc.cfg
+++ b/GameData/SPEngine/Parts/LR87_proc.cfg
@@ -30,7 +30,7 @@
 {
 	@name = SPEngineLR87
 	@title = T-class Procedural Engine
-	@description = Hypergolic atmospheric engine, like LR87 family (Titan II and later).
+	@description = Hypergolic atmospheric engine, like LR87 family (Titan II and later). <b><color=green>From ROEngines mod</color></b>
 	@TechRequired = orbitalRocketry1962
 	@MODEL
 	{

--- a/GameData/SPEngine/Parts/LR91_proc.cfg
+++ b/GameData/SPEngine/Parts/LR91_proc.cfg
@@ -25,7 +25,7 @@
 {
 	@name = SPEngineLR91
 	@title = E-class Procedural Engine
-	@description = Large hypergolic vacuum engine, like LR91 family (Titan II and later).
+	@description = Large hypergolic vacuum engine, like LR91 family (Titan II and later). <b><color=green>From ROEngines mod</color></b>
 	@TechRequired = orbitalRocketry1962
 	MODULE
 	{

--- a/GameData/SPEngine/Parts/LR91_proc.cfg
+++ b/GameData/SPEngine/Parts/LR91_proc.cfg
@@ -1,4 +1,27 @@
-+PART[liquidEngine1-2]:BEFORE[ZREALPLUME]
++PART[liquidEngine1-2]:NEEDS[!ROEngines]:BEFORE[ZREALPLUME]
+{
+	@name = SPEngineLR91
+	@title = E-class Procedural Engine
+	@description = Large hypergolic vacuum engine, like LR91 family (Titan II and later).
+	@TechRequired = orbitalRocketry1962
+	MODULE
+	{
+		name = ModuleSPEngine
+		familyLetter = E
+	}
+	@identicalParts = SPEngineLR91,SPEngineLR91Mini // we're not identical to the part we copied!
+	!engineType = // prevent ROE from deleting us
+	@MODULE[ModuleEngines*]
+	{
+		%powerEffectName = Hypergolic-Upper
+	}
+	@PLUME
+	{
+		@name = Hypergolic-Upper
+	}
+}
+
++PART[ROE-LR91]:NEEDS[ROEngines]:BEFORE[ZREALPLUME]
 {
 	@name = SPEngineLR91
 	@title = E-class Procedural Engine

--- a/GameData/SPEngine/Parts/NK_proc.cfg
+++ b/GameData/SPEngine/Parts/NK_proc.cfg
@@ -17,7 +17,7 @@
 {
 	@name = SPEngineNK15
 	@title = N-class Procedural Engine
-	@description = Large staged-combustion kerolox booster engine, like NK-15 family.
+	@description = Large staged-combustion kerolox booster engine, like NK-15 family. <b><color=green>From ROEngines mod</color></b>
 	@TechRequired = stagedCombustion1969
 	MODULE
 	{
@@ -47,7 +47,7 @@
 {
 	@name = SPEngineNK15V
 	@title = Y-class Procedural Engine
-	@description = Large staged-combustion kerolox vacuum engine, like NK-15V family.
+	@description = Large staged-combustion kerolox vacuum engine, like NK-15V family. <b><color=green>From ROEngines mod</color></b>
 	@TechRequired = stagedCombustion1969
 	MODULE
 	{

--- a/GameData/SPEngine/Parts/NK_proc.cfg
+++ b/GameData/SPEngine/Parts/NK_proc.cfg
@@ -1,4 +1,4 @@
-+PART[RO-RealEngines-NK-33]:BEFORE[ZREALPLUME]
++PART[RO-RealEngines-NK-33]:NEEDS[!ROEngines]:BEFORE[ZREALPLUME]
 {
 	@name = SPEngineNK15
 	@title = N-class Procedural Engine
@@ -13,7 +13,37 @@
 	!engineType = // prevent ROE from deleting us
 }
 
-+PART[RO-RealEngines-NK-43]:BEFORE[ZREALPLUME]
++PART[ROE-NK33]:NEEDS[ROEngines]:BEFORE[ZREALPLUME]
+{
+	@name = SPEngineNK15
+	@title = N-class Procedural Engine
+	@description = Large staged-combustion kerolox booster engine, like NK-15 family.
+	@TechRequired = stagedCombustion1969
+	MODULE
+	{
+		name = ModuleSPEngine
+		familyLetter = N
+	}
+	!identicalParts = // we're not identical to the part we copied!
+	!engineType = // prevent ROE from deleting us
+}
+
++PART[RO-RealEngines-NK-43]:NEEDS[!ROEngines]:BEFORE[ZREALPLUME]
+{
+	@name = SPEngineNK15V
+	@title = Y-class Procedural Engine
+	@description = Large staged-combustion kerolox vacuum engine, like NK-15V family.
+	@TechRequired = stagedCombustion1969
+	MODULE
+	{
+		name = ModuleSPEngine
+		familyLetter = Y
+	}
+	!identicalParts = // we're not identical to the part we copied!
+	!engineType = // prevent ROE from deleting us
+}
+
++PART[ROE-NK43]:NEEDS[ROEngines]:BEFORE[ZREALPLUME]
 {
 	@name = SPEngineNK15V
 	@title = Y-class Procedural Engine

--- a/GameData/SPEngine/Parts/RD58_proc.cfg
+++ b/GameData/SPEngine/Parts/RD58_proc.cfg
@@ -1,4 +1,18 @@
-+PART[RO-RD58]:AFTER[ZREALPLUME]
++PART[RO-RD58]:NEEDS[!ROEngines]:AFTER[ZREALPLUME]
+{
+	@name = SPEngineRD58
+	@title = S-class Procedural Engine
+	@description = Small staged-combustion kerolox vacuum engine, like S1.5400/RD-58.  Compared to hydrolox, kerolox upper stages have lower specific impulse but higher density and do not suffer boiloff as badly.
+	MODULE
+	{
+		name = ModuleSPEngine
+		familyLetter = S
+	}
+	!identicalParts = // we're not identical to the part we copied!
+	!engineType = // prevent ROE from deleting us
+}
+
++PART[ROE-RD58]:NEEDS[ROEngines]:AFTER[ZREALPLUME]
 {
 	@name = SPEngineRD58
 	@title = S-class Procedural Engine

--- a/GameData/SPEngine/Parts/RD58_proc.cfg
+++ b/GameData/SPEngine/Parts/RD58_proc.cfg
@@ -16,7 +16,7 @@
 {
 	@name = SPEngineRD58
 	@title = S-class Procedural Engine
-	@description = Small staged-combustion kerolox vacuum engine, like S1.5400/RD-58.  Compared to hydrolox, kerolox upper stages have lower specific impulse but higher density and do not suffer boiloff as badly.
+	@description = Small staged-combustion kerolox vacuum engine, like S1.5400/RD-58.  Compared to hydrolox, kerolox upper stages have lower specific impulse but higher density and do not suffer boiloff as badly. <b><color=green>From ROEngines mod</color></b>
 	MODULE
 	{
 		name = ModuleSPEngine

--- a/GameData/SPEngine/Parts/RL10_proc.cfg
+++ b/GameData/SPEngine/Parts/RL10_proc.cfg
@@ -1,4 +1,4 @@
-+PART[engineLargeSkipper]:AFTER[ZREALPLUME]
++PART[engineLargeSkipper]:NEEDS[!ROEngines]:AFTER[ZREALPLUME]
 {
 	@name = SPEngineRL10
 	@title = R-class Procedural Engine
@@ -12,7 +12,36 @@
 	!engineType = // prevent ROE from deleting us
 }
 
-+PART[engineLargeSkipper]:AFTER[ZREALPLUME]
++PART[engineLargeSkipper]:NEEDS[!ROEngines]:AFTER[ZREALPLUME]
+{
+	@name = SPEngineRL10Throt
+	@title = Q-class Procedural Engine
+	@description = Throttleable small hydrolox vacuum engine.  P&W worked on RL10 throttling for Project Lunex, and later DC-X.
+	%TechRequired = improvedHydrolox // later than the vanilla R-class.  To match the Q-0's techRequired.
+	MODULE
+	{
+		name = ModuleSPEngine
+		familyLetter = Q
+	}
+	!identicalParts = // we're not identical to the part we copied!
+	!engineType = // prevent ROE from deleting us
+}
+
++PART[ROE-RL10A3]:NEEDS[ROEngines]:AFTER[ZREALPLUME]
+{
+	@name = SPEngineRL10
+	@title = R-class Procedural Engine
+	@description = Small hydrolox vacuum engine, like RL10.
+	MODULE
+	{
+		name = ModuleSPEngine
+		familyLetter = R
+	}
+	!identicalParts = // we're not identical to the part we copied!
+	!engineType = // prevent ROE from deleting us
+}
+
++PART[ROE-RL10A3]:NEEDS[ROEngines]:AFTER[ZREALPLUME]
 {
 	@name = SPEngineRL10Throt
 	@title = Q-class Procedural Engine

--- a/GameData/SPEngine/Parts/RL10_proc.cfg
+++ b/GameData/SPEngine/Parts/RL10_proc.cfg
@@ -31,7 +31,7 @@
 {
 	@name = SPEngineRL10
 	@title = R-class Procedural Engine
-	@description = Small hydrolox vacuum engine, like RL10.
+	@description = Small hydrolox vacuum engine, like RL10. <b><color=green>From ROEngines mod</color></b>
 	MODULE
 	{
 		name = ModuleSPEngine
@@ -45,7 +45,7 @@
 {
 	@name = SPEngineRL10Throt
 	@title = Q-class Procedural Engine
-	@description = Throttleable small hydrolox vacuum engine.  P&W worked on RL10 throttling for Project Lunex, and later DC-X.
+	@description = Throttleable small hydrolox vacuum engine.  P&W worked on RL10 throttling for Project Lunex, and later DC-X. <b><color=green>From ROEngines mod</color></b>
 	%TechRequired = improvedHydrolox // later than the vanilla R-class.  To match the Q-0's techRequired.
 	MODULE
 	{

--- a/GameData/SPEngine/Parts/SSME_proc.cfg
+++ b/GameData/SPEngine/Parts/SSME_proc.cfg
@@ -2,7 +2,7 @@
 {
 	@name = SPEngineSSME
 	@title = H-class Procedural Engine
-	@description = Staged-combustion hydrolox sustainer engine, like HG-3-SL or RS25 (SSME).
+	@description = Staged-combustion hydrolox sustainer engine, like HG-3-SL or RS25 (SSME). <b><color=green>From ROEngines mod</color></b>
 	@TechRequired = hydrolox1976
 	MODULE
 	{


### PR DESCRIPTION
some engines weren't updated, either because ROEngines doesn't have their model or because a proper model doesn't exist at all (like Gamma)