### PR TITLE
Added speculative re-ignitions to E- and V-class engines

### DIFF
--- a/GameData/SPEngine/Families/E.cfg
+++ b/GameData/SPEngine/Families/E.cfg
@@ -95,7 +95,7 @@ SPEFamily:NEEDS[RealFuels]
 			name = ElectricCharge
 			amount = 0.8
 		}
-		maxIgnitions = 1
+		maxIgnitions = 3
 		mass = 0.7
 		entryCost = AJTitan-9
 		cost = 450
@@ -127,7 +127,7 @@ SPEFamily:NEEDS[RealFuels]
 			name = ElectricCharge
 			amount = 0.8
 		}
-		maxIgnitions = 1
+		maxIgnitions = 5
 		mass = 0.697
 		entryCost = AJTitan-11
 		cost = 460
@@ -159,7 +159,7 @@ SPEFamily:NEEDS[RealFuels]
 			name = ElectricCharge
 			amount = 0.8
 		}
-		maxIgnitions = 1
+		maxIgnitions = 5
 		mass = 0.697
 		entryCost = AJTitan-11
 		cost = 460

--- a/GameData/SPEngine/Families/E.cfg
+++ b/GameData/SPEngine/Families/E.cfg
@@ -95,7 +95,7 @@ SPEFamily:NEEDS[RealFuels]
 			name = ElectricCharge
 			amount = 0.8
 		}
-		maxIgnitions = 3
+		maxIgnitions = 1
 		mass = 0.7
 		entryCost = AJTitan-9
 		cost = 450
@@ -127,7 +127,7 @@ SPEFamily:NEEDS[RealFuels]
 			name = ElectricCharge
 			amount = 0.8
 		}
-		maxIgnitions = 5
+		maxIgnitions = 2
 		mass = 0.697
 		entryCost = AJTitan-11
 		cost = 460
@@ -159,7 +159,7 @@ SPEFamily:NEEDS[RealFuels]
 			name = ElectricCharge
 			amount = 0.8
 		}
-		maxIgnitions = 5
+		maxIgnitions = 3
 		mass = 0.697
 		entryCost = AJTitan-11
 		cost = 460

--- a/GameData/SPEngine/Families/V.cfg
+++ b/GameData/SPEngine/Families/V.cfg
@@ -158,7 +158,7 @@ SPEFamily:NEEDS[RealFuels]
 			name = ElectricCharge
 			amount = 0.8
 		}
-		maxIgnitions = 3
+		maxIgnitions = 2
 		mass = 0.757
 		entryCost = 10000
 		cost = 390

--- a/GameData/SPEngine/Families/V.cfg
+++ b/GameData/SPEngine/Families/V.cfg
@@ -132,6 +132,38 @@ SPEFamily:NEEDS[RealFuels]
 		cost = 380
 		toolCost = 14700 // yields 2001.2 to continue upgrading an LR91-AJ-3
 	}
+	TechLevel
+	{
+		// Speculative-LR91-AJ-11-Kero
+		techRequired = orbitalRocketry1970
+		maxThrust = 560
+		isp
+		{
+			key = 0 327.5
+			key = 1 167
+		}
+		PROPELLANT
+		{
+			name = Kerosene
+			ratio = 0.382
+			DrawGauge = True
+		}
+		PROPELLANT
+		{
+			name = LqdOxygen
+			ratio = 0.618
+		}
+		IGNITOR_RESOURCE
+		{
+			name = ElectricCharge
+			amount = 0.8
+		}
+		maxIgnitions = 3
+		mass = 0.757
+		entryCost = 10000
+		cost = 390
+		toolCost = 14700 // yields 2001.2 to continue upgrading an LR91-AJ-3
+	}
 	// There's a big gap here, when no-one was designing V-class engines — the US was busy with Hydrogen Über Alles (J- and later H-class), while Russia had gone down the staged-combustion route (Y-class).  The LR91 meanwhile had metamorphosed into a hypergolic engine (E-class).
 	TechLevel
 	{
@@ -160,7 +192,7 @@ SPEFamily:NEEDS[RealFuels]
 			amount = 0.5
 		}
 		// Should really have a TEATEB IGNITOR_RESOURCE on all these MVacs, but then the LR91s would have to carry it too.  Let's not bother
-		maxIgnitions = 1
+		maxIgnitions = 4
 		mass = 1.175
 		entryCost = 12000
 		cost = 325
@@ -311,42 +343,52 @@ SPEFamily:NEEDS[RealFuels]
 	}
 	TESTFLIGHT
 	{
-		name = SPEngine-V-4 // based on Merlin1BVac
+		name = SPEngine-V-4 // based on LR91-AJ-11 (should be -Kero, but there's no TF config for that)
+		ratedBurnTime = 250
+		ignitionReliabilityStart = 0.98
+		ignitionReliabilityEnd = 0.995
+		cycleReliabilityStart = 0.96514
+		cycleReliabilityEnd = 0.993
+		techTransfer = SPEngine-V-3,SPEngine-V-2,SPEngine-V-1,SPEngine-V-0:50&LR91-AJ-3:6
+	}
+	TESTFLIGHT
+	{
+		name = SPEngine-V-5 // based on Merlin1BVac
 		ratedBurnTime = 345
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
 		cycleReliabilityEnd = 0.995
-		techTransfer = SPEngine-V-3,SPEngine-V-2,SPEngine-V-1:50&Merlin1B:10&Merlin1A:5
+		techTransfer = SPEngine-V-4,SPEngine-V-3,SPEngine-V-2,SPEngine-V-1:50&Merlin1B:10&Merlin1A:5
 	}
 	TESTFLIGHT
 	{
-		name = SPEngine-V-5 // based on Merlin1CVac
+		name = SPEngine-V-6 // based on Merlin1CVac
 		ratedBurnTime = 345
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
 		cycleReliabilityEnd = 0.995
-		techTransfer = SPEngine-V-4,SPEngine-V-3,SPEngine-V-2:50&SPEngine-K-8:10&Merlin1BVac:25&Merlin1C:5
+		techTransfer = SPEngine-V-5,SPEngine-V-4,SPEngine-V-3,SPEngine-V-2:50&SPEngine-K-8:10&Merlin1BVac:25&Merlin1C:5
 	}
 	TESTFLIGHT
 	{
-		name = SPEngine-V-6 // based on Merlin1DVac
+		name = SPEngine-V-7 // based on Merlin1DVac
 		ratedBurnTime = 375
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
 		cycleReliabilityEnd = 0.995
-		techTransfer = SPEngine-V-5,SPEngine-V-4,SPEngine-V-3:50&SPEngine-K-9:10&Merlin1CVac,Merlin1BVac:25&Merlin1D:5
+		techTransfer = SPEngine-V-6,SPEngine-V-5,SPEngine-V-4,SPEngine-V-3:50&SPEngine-K-9:10&Merlin1CVac,Merlin1BVac:25&Merlin1D:5
 	}
 	TESTFLIGHT
 	{
-		name = SPEngine-V-7 // based on Merlin1DVac+
+		name = SPEngine-V-8 // based on Merlin1DVac+
 		ratedBurnTime = 400
 		ignitionReliabilityStart = 0.98
 		ignitionReliabilityEnd = 0.995
 		cycleReliabilityStart = 0.98
 		cycleReliabilityEnd = 0.995
-		techTransfer = SPEngine-V-6,SPEngine-V-5,SPEngine-V-4:50&SPEngine-K-10:10&Merlin1DVac,Merlin1CVac:25&Merlin1D+:5&Merlin1D++:5
+		techTransfer = SPEngine-V-7,SPEngine-V-6,SPEngine-V-5,SPEngine-V-4:50&SPEngine-K-10:10&Merlin1DVac,Merlin1CVac:25&Merlin1D+:5&Merlin1D++:5
 	}
 }


### PR DESCRIPTION
I think I got everything correct in adding a V-class config (shifted tech transfer, etc), but that could always stand double-checking.

Other than that, based on issue #10 .