### PR TITLE
Scale node locations to match the model scale

### DIFF
--- a/GameData/SPEngine/Parts/Gamma_proc.cfg
+++ b/GameData/SPEngine/Parts/Gamma_proc.cfg
@@ -87,6 +87,8 @@
 	@description = Kerosene/peroxide pump-fed vacuum engine, like Gamma 2.  One-axis gimbal; use in opposed pairs.  Upgrades are speculative.
 	@manufacturer = Bristol Siddeley
 	@TechRequired = basicRocketryRP0
+	@node_stack_top[1] *= 1.6
+	@node_stack_bottom[1] *= 1.6
 	@MODEL
 	{
 		%scale = 1.0, 1.6, 1.0 // long vacuum nozzle

--- a/GameData/SPEngine/Parts/LR87_proc.cfg
+++ b/GameData/SPEngine/Parts/LR87_proc.cfg
@@ -4,6 +4,8 @@
 	@title = T-class Procedural Engine
 	@description = Hypergolic atmospheric engine, like LR87 family (Titan II and later).
 	@TechRequired = orbitalRocketry1962
+	@node_stack_top[1] *= 0.7
+	@node_stack_bottom[1] *= 0.7
 	@MODEL
 	{
 		// Original part had 0.69 each way.  We want it narrower — a cluster of two should fit on a Titan.
@@ -32,6 +34,8 @@
 	@title = T-class Procedural Engine
 	@description = Hypergolic atmospheric engine, like LR87 family (Titan II and later). <b><color=green>From ROEngines mod</color></b>
 	@TechRequired = orbitalRocketry1962
+	@node_stack_top[1] *= 0.7
+	@node_stack_bottom[1] *= 0.7
 	@MODEL
 	{
 		// Half the thrust of original part, so let's halve the exit plane area


### PR DESCRIPTION
Model scaling doesn't seem to adjust the location of nodes, so the elongated vacuum Gamma had a bottom node inside the engine bell and the LR87 had floating nodes too far above/below the scaled model. This fixes both issues for me.